### PR TITLE
Correct files for partial charges prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Available benchmarking systems:
  * `bde` Bond dissociation enthalpies trained as single-task model
  * `bde_charges` Bond dissociation enthalpies trained as multi-task model together with atomic partial charges
  * `charges_eps_4` Partial charges at a dielectric constant of 4 (in protein)
- * `charges_eps_78` Partial charges at a dielectric constant of 78 (in protein)
+ * `charges_eps_78` Partial charges at a dielectric constant of 78 (in water)
  * `barriers_e2` Reaction barrier heights of E2 reactions
  * `barriers_sn2` Reaction barrier heights of SN2 reactions
  * `barriers_cycloadd` Reaction barrier heights of cycloaddition reactions

--- a/scripts/charges_eps_4.sh
+++ b/scripts/charges_eps_4.sh
@@ -10,10 +10,8 @@ train_constraints_path=../data/charges_eps_4/train_constraints.csv
 val_constraints_path=../data/charges_eps_4/val_constraints.csv
 test_constraints_path=../data/charges_eps_4/test_constraints.csv
 
-external_test_path1=../data/charges_eps_4/test_set_1.csv
-external_test_constraints_path1=../data/charges_eps_4/test_set_1_constraints.csv
-external_test_path2=../data/charges_eps_4/test_set_2.csv
-external_test_constraints_path2=../data/charges_eps_4/test_set_2_constraints.csv
+external_test_path=../data/charges_eps_4/external_test_set.csv
+external_test_constraints_path=../data/charges_eps_4/external_test_set_constraints.csv
 
 #Hyperparameter optimization
 python $chemprop_dir/hyperparameter_optimization.py \
@@ -57,16 +55,9 @@ python $chemprop_dir/train.py \
 --save_preds \
 --extra_metrics mae
 
-#Predict on external test set 1
+#Predict on external test set
 python $chemprop_dir/predict.py \
---test_path $external_test_path1 \
---constraints_path $external_test_constraints_path1 \
---preds_path $results_dir/preds_test1.csv \
---checkpoint_dir $results_dir
-
-#Predict on external test set 2
-python $chemprop_dir/predict.py \
---test_path $external_test_path2 \
---constraints_path $external_test_constraints_path2 \
---preds_path $results_dir/preds_test2.csv \
+--test_path $external_test_path \
+--constraints_path $external_test_constraints_path \
+--preds_path $results_dir/preds_external_test.csv \
 --checkpoint_dir $results_dir

--- a/scripts/charges_eps_78.sh
+++ b/scripts/charges_eps_78.sh
@@ -10,6 +10,9 @@ train_constraints_path=../data/charges_eps_78/train_constraints.csv
 val_constraints_path=../data/charges_eps_78/val_constraints.csv
 test_constraints_path=../data/charges_eps_78/test_constraints.csv
 
+external_test_path=../data/charges_eps_78/external_test_set.csv
+external_test_constraints_path=../data/charges_eps_78/external_test_set_constraints.csv
+
 #Hyperparameter optimization
 python $chemprop_dir/hyperparameter_optimization.py \
 --dataset_type regression \
@@ -52,4 +55,9 @@ python $chemprop_dir/train.py \
 --save_preds \
 --extra_metrics mae
 
-
+#Predict on external test set
+python $chemprop_dir/predict.py \
+--test_path $external_test_path \
+--constraints_path $external_test_constraints_path \
+--preds_path $results_dir/preds_external_test.csv \
+--checkpoint_dir $results_dir


### PR DESCRIPTION
Thanks for compiling these datasets! It is very clean and concise.

There are two things I would like to correct in this PR:
1. There is a typo in the README. The system with a dielectric constant of 78 is `in water`.
2. There are two external test sets for testing the models trained on datasets with dielectric constants of 4 and 78, respectively. Therefore, I modified scripts for those two models. I apologize for any confusion on my part. In the meantime, could you please modify the file names for those two external test sets and move the external test set files for the model with the dielectric constant of 78 to the correct folder in the dataset, which is located at `../data/charges_eps_78`? Thanks!