### PR TITLE
updates to scripts with v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository contains benchmarking scripts and data for Chemprop, a message p
 
 ## Data
 
-All datasets used in the study can be downloaded from [Zenodo](https://doi.org/10.5281/zenodo.8174268). You can either download and extract the file data.tar.gz yourself, or run
+All datasets used in the study can be downloaded from [Zenodo](https://doi.org/10.5281/zenodo.8174267). You can either download and extract the file data.tar.gz yourself, or run
 
 ```
-wget https://zenodo.org/record/8174268/files/data.tar.gz
+wget https://zenodo.org/record/8174267/files/data.tar.gz
 tar -xzvf data.tar.gz
 ```
 
@@ -26,7 +26,8 @@ This will run a hyperparameter search, as well as a training run on the best hyp
 
 Available benchmarking systems:
  * `hiv` HIV replication inhibition from MoleculeNet and OGB with scaffold splits
- * `pcba_random` Biological activities from MoleculeNet and OGB with random splits
+ * `pcba_random` Biological activities from MoleculeNet with random splits
+ * `pcba_random_nans` Biological activities from MoleculeNet with missing targets NOT set to zero (to be comparable to the OGB version) with random splits
  * `pcba_scaffold` Biological activities from MoleculeNet and OGB with scaffold splits
  * `qm9_multitask` DFT calculated properties from MoleculeNet and OGB, trained as a multi-task model
  * `qm9_u0` DFT calculated properties from MoleculeNet and OGB, trained as a single-task model on the target U0 only
@@ -50,4 +51,4 @@ Available benchmarking systems:
  * `uncertainty_mve` Uncertainty estimation using mean-variance estimation using the QM9 gap dataset
  * `timing` Timing benchmark using subsets of QM9 gap
 
-Most benchmarks were done on the master branch of Chemprop as of March 2023, commit [0c129c9](https://github.com/chemprop/chemprop/commit/0c129b985868a98331edc728e75d59024778ee4c) which extends functionalities of the [v1.5.2](https://github.com/chemprop/chemprop/releases/tag/v1.5.2) release of Chemprop, and will be part of the upcoming v1.6 release. The only exception is the `timing` benchmarks, which were run on the [`benchmark_timing`](https://github.com/chemprop/chemprop/tree/benchmark_timing) branch that includes timing printouts.
+The benchmarks were done on the master branch of [Chemprop v1.6.1](https://github.com/chemprop/chemprop/tree/v1.6.1). The only exception is the `timing` benchmarks, which were run on the [`benchmark_timing`](https://github.com/chemprop/chemprop/tree/benchmark_timing) branch that includes timing printouts. However, they can also be run on the master branch, although with less verbous printouts.

--- a/scripts/charges_eps_4.sh
+++ b/scripts/charges_eps_4.sh
@@ -29,7 +29,7 @@ python $chemprop_dir/hyperparameter_optimization.py \
 --config_save_path $results_dir/config.json \
 --hyperopt_checkpoint_dir $results_dir \
 --log_dir $results_dir \
---keeping_atom_map \
+--adding_h \
 --is_atom_bond_targets \
 --no_shared_atom_bond_ffn \
 --no_adding_bond_types
@@ -47,7 +47,7 @@ python $chemprop_dir/train.py \
 --aggregation norm \
 --config_path $results_dir/config.json \
 --save_dir $results_dir \
---keeping_atom_map \
+--adding_h \
 --is_atom_bond_targets \
 --no_shared_atom_bond_ffn \
 --no_adding_bond_types \

--- a/scripts/charges_eps_78.sh
+++ b/scripts/charges_eps_78.sh
@@ -29,7 +29,7 @@ python $chemprop_dir/hyperparameter_optimization.py \
 --config_save_path $results_dir/config.json \
 --hyperopt_checkpoint_dir $results_dir \
 --log_dir $results_dir \
---keeping_atom_map \
+--adding_h \
 --is_atom_bond_targets \
 --no_shared_atom_bond_ffn \
 --no_adding_bond_types
@@ -47,7 +47,7 @@ python $chemprop_dir/train.py \
 --aggregation norm \
 --config_path $results_dir/config.json \
 --save_dir $results_dir \
---keeping_atom_map \
+--adding_h \
 --is_atom_bond_targets \
 --no_shared_atom_bond_ffn \
 --no_adding_bond_types \

--- a/scripts/pcba_random_nans.sh
+++ b/scripts/pcba_random_nans.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+chemprop_dir=../../../chemprop  # location of chemprop directory, CHANGE ME
+
+results_dir=results_pcba_random_nans
+train_path=../data/pcba_random_nans/train.csv
+val_path=../data/pcba_random_nans/val.csv
+test_path=../data/pcba_random_nans/test.csv
+
+#Hyperparameter optimization
+python $chemprop_dir/hyperparameter_optimization.py \
+--dataset_type classification \
+--data_path $train_path \
+--separate_val_path $val_path \
+--separate_test_path $val_path \
+--num_iters 30 \
+--epochs 50 \
+--aggregation norm \
+--search_parameter_keywords depth ffn_num_layers  hidden_size ffn_hidden_size dropout \
+--config_save_path $results_dir/config.json \
+--hyperopt_checkpoint_dir $results_dir \
+--log_dir $results_dir 
+
+#Training with optimized hyperparameters
+python $chemprop_dir/train.py \
+--dataset_type classification \
+--data_path $train_path \
+--separate_val_path $val_path \
+--separate_test_path $test_path \
+--epochs 50 \
+--aggregation norm \
+--config_path $results_dir/config.json \
+--save_dir $results_dir \
+--ensemble_size 5 \
+--save_preds \
+--extra_metrics prc-auc
+

--- a/scripts/sampl.sh
+++ b/scripts/sampl.sh
@@ -10,7 +10,7 @@ test_path=../data/logP/test.csv
 path=../data/logP/logP_without_overlap.csv
 
 #Hyperparameter optimization
-#python $chemprop_dir/hyperparameter_optimization.py \
+python $chemprop_dir/hyperparameter_optimization.py \
 --dataset_type regression \
 --data_path $train_path \
 --separate_val_path $val_path \


### PR DESCRIPTION
This PR updates our scripts to Chemprop v1.6.1 + some bug fixes:
- In the README, I changed the Zenodo link to a versioned Zenodo link that will always point to the latest version
- I changed the "Reproducibility" section to reflect that this was run on v1.6.1 only
- For the `charges_eps_4` and `charges_eps_78` benchmarks, the scripts changed slightly (as well as the data) since loading custom atom-orders has a bug in v1.6.1 that will be fixed in v1.6.2
- I fixed a typo in `sampl.sh`
- I added the benchmark system `pcba_random_nans` after we found out that the splits from MoleculeNet and OGB are different in that MoleculeNet fills in zeros for NaN values - to be comparable with both leaderboards, we now allow both options for the random split.

This PR will be accompanied by a change of our Zenodo dataset:
- Removed hidden files that accidentally were included in the last version
- updated all files for the `charges_eps_4` and `charges_eps_78` benchmarks (atom ordering changed due to the bug in v1.6.1). The old file was compatible with all version but v1.6.1. The new file is compatible with all versions of chemprop (that support atom targets) including v1.6.1.
- added the `pcba_random_nans` dataset
- removed one class from the `pcba_scaffold` dataset which was not existent in the test set causing errors during evaluation and testing.